### PR TITLE
Fix some spelling errors in manpages

### DIFF
--- a/Statistics-Descriptive/lib/Statistics/Descriptive/Full.pm
+++ b/Statistics-Descriptive/lib/Statistics/Descriptive/Full.pm
@@ -1131,7 +1131,7 @@ B<$Type> is an integer value between 0 to 4 :
   3 => third quartile (Q3) : upper quartile = highest cut off (25%) of data, or lowest 75% = 75th percentile
   4 => fourth quartile (Q4) : maximal value
 
-Exemple :
+Example :
 
   my @data = (1..10);
   my $stat = Statistics::Descriptive::Full->new();
@@ -1159,7 +1159,7 @@ Returns the geometric mean of the data.
 
 =item my $mode = $stat->mode();
 
-Returns the mode of the data. The mode is the most commonly occuring datum.
+Returns the mode of the data. The mode is the most commonly occurring datum.
 See L<http://en.wikipedia.org/wiki/Mode_%28statistics%29> . If all values
 occur only once, then mode() will return undef.
 

--- a/Statistics-Descriptive/lib/Statistics/Descriptive/Sparse.pm
+++ b/Statistics-Descriptive/lib/Statistics/Descriptive/Sparse.pm
@@ -540,7 +540,7 @@ B<$Type> is an integer value between 0 to 4 :
   3 => third quartile (Q3) : upper quartile = highest cut off (25%) of data, or lowest 75% = 75th percentile
   4 => fourth quartile (Q4) : maximal value
 
-Exemple :
+Example :
 
   my @data = (1..10);
   my $stat = Statistics::Descriptive::Full->new();
@@ -568,7 +568,7 @@ Returns the geometric mean of the data.
 
 =item my $mode = $stat->mode();
 
-Returns the mode of the data. The mode is the most commonly occuring datum.
+Returns the mode of the data. The mode is the most commonly occurring datum.
 See L<http://en.wikipedia.org/wiki/Mode_%28statistics%29> . If all values
 occur only once, then mode() will return undef.
 


### PR DESCRIPTION

Hi

In Debian we are currently applying the following patch to
Statistics-Descriptive.
We thought you might be interested in it too.

    Description: Fix some spelling errors in manpages
    Origin: vendor
    Author: Salvatore Bonaccorso <carnil@debian.org>
    Last-Update: 2018-07-14
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libstatistics-descriptive-perl/raw/master/debian/patches/spelling-error-in-manpage.patch

Thanks for considering,
  Salvatore Bonaccorso,
  Debian Perl Group
